### PR TITLE
Fix inclusive counting esrnn

### DIFF
--- a/nbs/models_esrnn__esrnn.ipynb
+++ b/nbs/models_esrnn__esrnn.ipynb
@@ -870,7 +870,7 @@
     "            max_time_stamp = int(av_condition.max())\n",
     "        else:\n",
     "            max_time_stamp = int(sample_condition.max())\n",
-    "        available_ts = max_time_stamp - min_time_stamp\n",
+    "        available_ts = max_time_stamp - min_time_stamp + 1 # +1, inclusive counting\n",
     "        if available_ts < self.input_size + self.output_size:\n",
     "            raise Exception(\n",
     "                'Time series too short for given input and output size. \\n'\n",

--- a/nixtlats/models/esrnn/esrnn.py
+++ b/nixtlats/models/esrnn/esrnn.py
@@ -641,7 +641,7 @@ class ESRNN(pl.LightningModule):
             max_time_stamp = int(av_condition.max())
         else:
             max_time_stamp = int(sample_condition.max())
-        available_ts = max_time_stamp - min_time_stamp
+        available_ts = max_time_stamp - min_time_stamp + 1 # +1, inclusive counting
         if available_ts < self.input_size + self.output_size:
             raise Exception(
                 'Time series too short for given input and output size. \n'


### PR DESCRIPTION
It was required to add one to the available timestamps (`availablets`) for the count to be inclusive. 
﻿
